### PR TITLE
Potential fix for code scanning alert no. 53: User-controlled data in numeric cast

### DIFF
--- a/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3CodecUtils.java
+++ b/codec-http3/src/main/java/io/netty/handler/codec/http3/Http3CodecUtils.java
@@ -149,6 +149,9 @@ final class Http3CodecUtils {
                 encodeLengthIntoBuffer(out, writerIndex, (byte) 0x40);
                 break;
             case 4:
+                if (value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+                    throw new IllegalArgumentException("Value out of range for int: " + value);
+                }
                 out.writeInt((int) value);
                 encodeLengthIntoBuffer(out, writerIndex, (byte) 0x80);
                 break;


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/netty/security/code-scanning/53](https://github.com/codeallthethingsbreak/netty/security/code-scanning/53)

To fix the issue, we need to validate the `value` parameter before casting it to `int`. Specifically:
1. Add a guard to ensure that `value` is within the range of `int` (`Integer.MIN_VALUE` to `Integer.MAX_VALUE`) before performing the cast.
2. If the value is out of range, throw an `IllegalArgumentException` to prevent unintended truncation.
3. Ensure that the fix does not alter the existing functionality of the method.

The changes will be made in the `writeVariableLengthInteger` method in `Http3CodecUtils.java`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
